### PR TITLE
upgrade from Starknet 2.7.0 to 2.8.5

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.7.0
-starknet-foundry 0.26.0
+scarb 2.8.5
+starknet-foundry 0.31.0

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -5,111 +5,60 @@ version = 1
 name = "cartridge_vrf"
 version = "0.1.0"
 dependencies = [
- "openzeppelin",
+ "openzeppelin_access",
  "openzeppelin_testing",
+ "openzeppelin_upgrades",
  "openzeppelin_utils",
  "snforge_std",
  "stark_vrf",
 ]
 
 [[package]]
-name = "openzeppelin"
-version = "0.15.0-rc.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?rev=a13bae3#a13bae3390a7114a8c14c0352c6898eff5f4f5d7"
-dependencies = [
- "openzeppelin_access",
- "openzeppelin_account",
- "openzeppelin_governance",
- "openzeppelin_introspection",
- "openzeppelin_presets",
- "openzeppelin_security",
- "openzeppelin_token",
- "openzeppelin_upgrades",
- "openzeppelin_utils",
-]
-
-[[package]]
 name = "openzeppelin_access"
-version = "0.15.0-rc.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?rev=a13bae3#a13bae3390a7114a8c14c0352c6898eff5f4f5d7"
+version = "0.19.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.19.0#8d49e8c445efd9bdc99b050c8b7d11ae5ad19628"
 dependencies = [
  "openzeppelin_introspection",
  "openzeppelin_utils",
-]
-
-[[package]]
-name = "openzeppelin_account"
-version = "0.15.0-rc.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?rev=a13bae3#a13bae3390a7114a8c14c0352c6898eff5f4f5d7"
-dependencies = [
- "openzeppelin_introspection",
- "openzeppelin_token",
- "openzeppelin_utils",
-]
-
-[[package]]
-name = "openzeppelin_governance"
-version = "0.15.0-rc.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?rev=a13bae3#a13bae3390a7114a8c14c0352c6898eff5f4f5d7"
-dependencies = [
- "openzeppelin_access",
- "openzeppelin_introspection",
 ]
 
 [[package]]
 name = "openzeppelin_introspection"
-version = "0.15.0-rc.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?rev=a13bae3#a13bae3390a7114a8c14c0352c6898eff5f4f5d7"
-
-[[package]]
-name = "openzeppelin_presets"
-version = "0.15.0-rc.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?rev=a13bae3#a13bae3390a7114a8c14c0352c6898eff5f4f5d7"
-dependencies = [
- "openzeppelin_access",
- "openzeppelin_account",
- "openzeppelin_introspection",
- "openzeppelin_token",
- "openzeppelin_upgrades",
-]
-
-[[package]]
-name = "openzeppelin_security"
-version = "0.15.0-rc.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?rev=a13bae3#a13bae3390a7114a8c14c0352c6898eff5f4f5d7"
+version = "0.19.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.19.0#8d49e8c445efd9bdc99b050c8b7d11ae5ad19628"
 
 [[package]]
 name = "openzeppelin_testing"
-version = "0.15.0-rc.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?rev=a13bae3#a13bae3390a7114a8c14c0352c6898eff5f4f5d7"
+version = "0.19.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.19.0#8d49e8c445efd9bdc99b050c8b7d11ae5ad19628"
 dependencies = [
  "snforge_std",
 ]
 
 [[package]]
-name = "openzeppelin_token"
-version = "0.15.0-rc.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?rev=a13bae3#a13bae3390a7114a8c14c0352c6898eff5f4f5d7"
-dependencies = [
- "openzeppelin_account",
- "openzeppelin_governance",
- "openzeppelin_introspection",
-]
-
-[[package]]
 name = "openzeppelin_upgrades"
-version = "0.15.0-rc.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?rev=a13bae3#a13bae3390a7114a8c14c0352c6898eff5f4f5d7"
+version = "0.19.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.19.0#8d49e8c445efd9bdc99b050c8b7d11ae5ad19628"
 
 [[package]]
 name = "openzeppelin_utils"
-version = "0.15.0-rc.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?rev=a13bae3#a13bae3390a7114a8c14c0352c6898eff5f4f5d7"
+version = "0.19.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.19.0#8d49e8c445efd9bdc99b050c8b7d11ae5ad19628"
+
+[[package]]
+name = "snforge_scarb_plugin"
+version = "0.31.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:1fce075fcbf7fce1b0935f6f9a034549704837fb221da212d3b6e9134cebfdaa"
 
 [[package]]
 name = "snforge_std"
-version = "0.26.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.26.0#50eb589db65e113efe4f09241feb59b574228c7e"
+version = "0.31.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:60ac980b297281f9a59a5f1668cb56bdea1b28fd2f8008008270f9a3c91ad3ba"
+dependencies = [
+ "snforge_scarb_plugin",
+]
 
 [[package]]
 name = "stark_vrf"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -4,14 +4,15 @@ version = "0.1.0"
 edition = "2023_10"
 
 [dependencies]
-starknet = "2.7.0"
+starknet = "2.8.5"
 stark_vrf = { git = "https://github.com/dojoengine/stark-vrf.git" }
-openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", rev = "a13bae3" }
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.26.0" }
+openzeppelin_access = { git = "https://github.com/openzeppelin/cairo-contracts", tag = "v0.19.0"}
+openzeppelin_upgrades = { git = "https://github.com/openzeppelin/cairo-contracts", tag = "v0.19.0"}
+snforge_std = "0.31.0"
 
 [dev-dependencies]
-openzeppelin_testing = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", rev = "a13bae3" }
-openzeppelin_utils = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", rev = "a13bae3" }
+openzeppelin_testing = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.19.0"}
+openzeppelin_utils = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.19.0"}
 
 [[target.starknet-contract]]
 allowed-libfuncs-list.name = "experimental"

--- a/src/mocks/vrf_consumer_mock.cairo
+++ b/src/mocks/vrf_consumer_mock.cairo
@@ -15,8 +15,8 @@ mod VrfConsumer {
     use starknet::{ClassHash, ContractAddress, get_caller_address, get_contract_address};
     use starknet::storage::Map;
 
-    use openzeppelin::upgrades::UpgradeableComponent;
-    use openzeppelin::upgrades::interface::IUpgradeable;
+    use openzeppelin_upgrades::UpgradeableComponent;
+    use openzeppelin_upgrades::interface::IUpgradeable;
 
     use stark_vrf::ecvrf::{Point, Proof, ECVRF, ECVRFImpl};
 

--- a/src/tests/common.cairo
+++ b/src/tests/common.cairo
@@ -1,6 +1,8 @@
 use openzeppelin_testing as utils;
 use openzeppelin_utils::serde::SerializedAppend;
-use snforge_std::{start_cheat_caller_address, stop_cheat_caller_address, cheat_max_fee_global};
+use snforge_std::{
+    start_cheat_caller_address, stop_cheat_caller_address, start_cheat_max_fee_global
+};
 use starknet::{ContractAddress, contract_address_const};
 use stark_vrf::ecvrf::Proof;
 use utils::constants::{AUTHORIZED, OWNER};
@@ -60,7 +62,7 @@ pub fn setup() -> SetupResult {
     utils::declare_and_deploy_at("VrfConsumer", CONSUMER1(), consumer_calldata.clone());
     utils::deploy_another_at(CONSUMER1(), CONSUMER2(), consumer_calldata);
 
-    cheat_max_fee_global(10000000000000000);
+    start_cheat_max_fee_global(10000000000000000);
 
     SetupResult {
         provider: IVrfProviderDispatcher { contract_address: PROVIDER() },

--- a/src/vrf_provider/vrf_provider.cairo
+++ b/src/vrf_provider/vrf_provider.cairo
@@ -4,9 +4,9 @@
 #[starknet::contract]
 mod VrfProvider {
     use starknet::{ContractAddress, ClassHash};
-    use openzeppelin::access::ownable::OwnableComponent;
-    use openzeppelin::upgrades::UpgradeableComponent;
-    use openzeppelin::upgrades::interface::IUpgradeable;
+    use openzeppelin_access::ownable::OwnableComponent;
+    use openzeppelin_upgrades::UpgradeableComponent;
+    use openzeppelin_upgrades::interface::IUpgradeable;
 
     use cartridge_vrf::vrf_provider::vrf_provider_component::VrfProviderComponent;
     use cartridge_vrf::PublicKey;

--- a/src/vrf_provider/vrf_provider_component.cairo
+++ b/src/vrf_provider/vrf_provider_component.cairo
@@ -38,7 +38,7 @@ pub mod VrfProviderComponent {
     use core::poseidon::poseidon_hash_span;
     use starknet::storage::Map;
 
-    use openzeppelin::access::ownable::{
+    use openzeppelin_access::ownable::{
         OwnableComponent, OwnableComponent::InternalImpl as OwnableInternalImpl
     };
 


### PR DESCRIPTION
* starknet: 2.7.0 => 2.8.5
* openzeppelin: a13bae3 => 0.19.0
* snforge: 0.26.0 => 0.31.0
* specify targeted dependencies in Scarb.toml for more efficient builds and to reduce upstream package dependency conflicts
* account for snforge changing cheatcode `cheat_max_fee_global` to `start_cheat_max_fee_global`