### PR TITLE
chore: use scarbz.xyz instead of tag for OZ deps

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -16,7 +16,8 @@ dependencies = [
 [[package]]
 name = "openzeppelin_access"
 version = "0.18.0"
-source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.18.0#2f37306b490e63c0afa9e33ad192ba428141b487"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:424314072ae27d5b6f4264472a5c403711448ea62763a661b89e6ff5f23297fd"
 dependencies = [
  "openzeppelin_introspection",
  "openzeppelin_utils",
@@ -25,12 +26,14 @@ dependencies = [
 [[package]]
 name = "openzeppelin_introspection"
 version = "0.18.0"
-source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.18.0#2f37306b490e63c0afa9e33ad192ba428141b487"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:46c4cc6c95c9baa4c7d5cc0ed2bdaf334f46c25a8c92b3012829fff936e3042b"
 
 [[package]]
 name = "openzeppelin_testing"
 version = "0.18.0"
-source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.18.0#2f37306b490e63c0afa9e33ad192ba428141b487"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:87a8f984f68870e0039fa678112a22ec67db263e53b5faa23775f495b14455d1"
 dependencies = [
  "snforge_std",
 ]
@@ -38,12 +41,14 @@ dependencies = [
 [[package]]
 name = "openzeppelin_upgrades"
 version = "0.18.0"
-source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.18.0#2f37306b490e63c0afa9e33ad192ba428141b487"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:33c9d0865364fc18a5e7b471fe53c3b0f3e0aec56a94f435089638fad2a4a35b"
 
 [[package]]
 name = "openzeppelin_utils"
 version = "0.18.0"
-source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.18.0#2f37306b490e63c0afa9e33ad192ba428141b487"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:725b212839f3eddc32791408609099c5e808c167ca0cf331d8c1d778b07a4e21"
 
 [[package]]
 name = "snforge_scarb_plugin"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -6,13 +6,13 @@ edition = "2023_10"
 [dependencies]
 starknet = "2.9.2"
 stark_vrf = { git = "https://github.com/dojoengine/stark-vrf.git" }
-openzeppelin_access = { git = "https://github.com/openzeppelin/cairo-contracts", tag = "v0.18.0" }
-openzeppelin_upgrades = { git = "https://github.com/openzeppelin/cairo-contracts", tag = "v0.18.0" }
+openzeppelin_access = "0.18.0"
+openzeppelin_upgrades = "0.18.0"
 snforge_std = "0.31.0"
 
 [dev-dependencies]
-openzeppelin_testing = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.18.0" }
-openzeppelin_utils = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.18.0" }
+openzeppelin_testing = "0.18.0"
+openzeppelin_utils = "0.18.0"
 
 [[target.starknet-contract]]
 allowed-libfuncs-list.name = "experimental"


### PR DESCRIPTION
This unlock third parties to use other versions of OZ without conflicts.